### PR TITLE
Fixed Ctrl+S overload

### DIFF
--- a/src/visualstates/gui/visualstates.py
+++ b/src/visualstates/gui/visualstates.py
@@ -86,7 +86,7 @@ class VisualStates(QMainWindow):
         saveAction.triggered.connect(self.saveAction)
 
         saveAsAction = QAction('&Save As', self)
-        saveAsAction.setShortcut('Ctrl+S')
+        saveAsAction.setShortcut('Ctrl+Shift+S')
         saveAsAction.setStatusTip('Save Visual States as New One')
         saveAsAction.triggered.connect(self.saveAsAction)
 


### PR DESCRIPTION
Changed the shortcut of Save As from Ctrl+S to Ctrl+Shift+S and left shortcut of Save same.